### PR TITLE
Fix an absolute path error not loading skins

### DIFF
--- a/AdoptSkin/Framework/SaveLoadHandler.cs
+++ b/AdoptSkin/Framework/SaveLoadHandler.cs
@@ -380,9 +380,9 @@ namespace AdoptSkin.Framework
 
             // Add custom sprites
             foreach (string path in Directory.EnumerateFiles(Path.Combine(SHelper.DirectoryPath, "assets", "skins"), "*", SearchOption.AllDirectories))
-                PullSprite(path);
+                PullSprite(path.Replace(SHelper.DirectoryPath, "")); // Fix an absolute path error
             // Grab the directory for the /Mods folder from the /Mods/AdoptSkin
-            
+
             //string modFolderPath = SHelper.DirectoryPath
             foreach (string path in Directory.EnumerateFiles(Path.Combine(SHelper.DirectoryPath)))
 

--- a/AdoptSkin/Framework/SaveLoadHandler.cs
+++ b/AdoptSkin/Framework/SaveLoadHandler.cs
@@ -380,7 +380,7 @@ namespace AdoptSkin.Framework
 
             // Add custom sprites
             foreach (string path in Directory.EnumerateFiles(Path.Combine(SHelper.DirectoryPath, "assets", "skins"), "*", SearchOption.AllDirectories))
-                PullSprite(path.Replace(SHelper.DirectoryPath, "")); // Fix an absolute path error
+                PullSprite(Path.GetRelativePath(SHelper.DirectoryPath, path)); // must be a relative path
             // Grab the directory for the /Mods folder from the /Mods/AdoptSkin
 
             //string modFolderPath = SHelper.DirectoryPath


### PR DESCRIPTION
I had an error not loading the skins because the path is absolute. I am not very familiar with C# but this fixes the error and should load the skins.